### PR TITLE
✨ 放送リスト取得機能 #19

### DIFF
--- a/src/routes/broadcast/index.ts
+++ b/src/routes/broadcast/index.ts
@@ -17,6 +17,13 @@ type PutBody = {
 const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
   // Broadcastプラグインを読み込む！
   await fastify.register(broadcastPlugin);
+
+  // 放送リスト取得機能
+  fastify.get('/', async (req, res) => {
+    const resultBroadcastList = await fastify.getBroadcastList();
+    res.send(resultBroadcastList);
+  })
+
   // 放送情報取得
   fastify.get<{
     Params: { id: number };
@@ -30,6 +37,7 @@ const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
     res.send(resultBroadcastInfo);
   });
 
+  // 放送作成機能
   fastify.post<{ Body: PostBody }>(`/`, async (req, res) => {
     const token = req?.headers?.authorization?.split(' ')[1] as string;
     const resultCreateBroadcastInfo = await fastify.createBroadcast({
@@ -40,6 +48,7 @@ const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
     res.send(resultCreateBroadcastInfo);
   });
 
+  // 放送情報更新機能
   fastify.put<{ Body: PutBody }>(`/`, async (req, res) => {
     const token = req?.headers?.authorization?.split(' ')[1] as string;
     const resultUpdateBroadcastInfo = await fastify.updateBroadcast({
@@ -49,7 +58,7 @@ const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
     res.send(resultUpdateBroadcastInfo);
   });
 
-  // コメント
+  // 放送削除機能
   fastify.delete<{
     Params: { id: number };
   }>(`/:id`, async (req, res) => {


### PR DESCRIPTION
## 変更内容（必須）
@miyasan31 に実装してもらったはずの放送リスト取得処理のコードが消えていたので、再度実装した。

## 確認して欲しい項目（必須）
放送一覧が取得できるかどうか

## どうやって確認するのか（必須）
- このブランチを git pull
- 必要な場合は、依存パッケージをインストール
- yarn dev でAPIを起動
- postmanなどのツールで、 GET ttp://0.0.0.0:8080/broadcast にアクセスし、放送一覧が取得できるか確認する。

## 備考
エンドポイントを変更した
http://localhost:3001/broadcastList　⇨　http://localhost:3001/broadcast

Closes #19 