### PR TITLE
放送を削除する際、トリビアが削除できていなかったバグを修正

### DIFF
--- a/src/routes/broadcast/index.ts
+++ b/src/routes/broadcast/index.ts
@@ -1,18 +1,19 @@
-import { FastifyPluginAsync } from "fastify";
-import broadcastPlugin from "./service";
+import { FastifyPluginAsync } from 'fastify';
+import broadcastPlugin from './service';
 
 type PostBody = {
   title: string;
   scheduledStartTime: string;
+  token: string;
 };
 
 type PutBody = {
-  id: number;
   title?: string;
   scheduledStartTime?: string;
   status?: string;
   archiveUrl?: string;
-}
+  token: string;
+};
 
 const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
   // Broadcastプラグインを読み込む！
@@ -22,14 +23,14 @@ const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
   fastify.get('/', async (req, res) => {
     const resultBroadcastList = await fastify.getBroadcastList();
     res.send(resultBroadcastList);
-  })
+  });
 
   // 放送情報取得
   fastify.get<{
     Params: { id: number };
   }>(`/:id`, async (req, res) => {
     const { id } = req.params;
-    const token = req?.headers?.authorization?.split(" ")[1] as string;
+    const token = req?.headers?.authorization?.split(' ')[1] as string;
     const resultBroadcastInfo = await fastify.getBroadcast({
       id: Number(id),
       token,
@@ -39,24 +40,32 @@ const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
 
   // 放送作成機能
   fastify.post<{ Body: PostBody }>(`/`, async (req, res) => {
-    const token = req?.headers?.authorization?.split(' ')[1] as string;
+    const { title, scheduledStartTime, token } = req.body;
     const resultCreateBroadcastInfo = await fastify.createBroadcast({
-      title: req.body.title,
-      scheduledStartTime: req.body.scheduledStartTime,
+      title,
+      scheduledStartTime,
       token,
     });
     res.send(resultCreateBroadcastInfo);
   });
 
   // 放送情報更新機能
-  fastify.put<{ Body: PutBody }>(`/`, async (req, res) => {
-    const token = req?.headers?.authorization?.split(' ')[1] as string;
-    const resultUpdateBroadcastInfo = await fastify.updateBroadcast({
-      ...req.body,
-      token,
-    });
-    res.send(resultUpdateBroadcastInfo);
-  });
+  fastify.put<{ Params: { id: number }; Body: PutBody }>(
+    `/:id`,
+    async (req, res) => {
+      const { id } = req.params;
+      const { title, scheduledStartTime, status, archiveUrl, token } = req.body;
+      const resultUpdateBroadcastInfo = await fastify.updateBroadcast({
+        id: Number(id),
+        title,
+        scheduledStartTime,
+        status,
+        archiveUrl,
+        token,
+      });
+      res.send(resultUpdateBroadcastInfo);
+    },
+  );
 
   // 放送削除機能
   fastify.delete<{
@@ -70,6 +79,6 @@ const broadcast: FastifyPluginAsync = async (fastify): Promise<void> => {
     });
     res.send(resultDeleteBroadcastInfo);
   });
-}
+};
 
 export default broadcast;

--- a/src/routes/broadcast/service.ts
+++ b/src/routes/broadcast/service.ts
@@ -178,7 +178,7 @@ const broadcastPlugin: FastifyPluginAsync = async (fastify) => {
   });
 
   // ---------------------- 放送削除 --------------------- //
-  fastify.decorate('deleteBroadcast', async (params: DeleteParams) => {
+  fastify.decorate('deleteBroadcast', async (params: DeleteParams): Promise<Broadcast> => {
     if (!params.token) {
       throw new Error('Specify token');
     }
@@ -196,7 +196,7 @@ const broadcastPlugin: FastifyPluginAsync = async (fastify) => {
         where: { broadcastId: params.id }
       });
       const result = await fastify.prisma.$transaction([deleteTrivia, deleteBroadcast]);
-      return result;
+      return result[1];
     }
 
     // 管理者ではない場合


### PR DESCRIPTION
## 変更した部分
前に実装していた放送削除機能の部分を、トランザクション処理でトリビア情報と放送情報を削除する機能に変更した

## 確認事項
- 放送を削除した後、prisma studioでトリビアテーブルが閲覧できるか
- 削除された放送に投稿されたトリビアも削除されているか

## 確認方法
- DELETE /broadcast/:id エンドポイントにアクセスして、放送削除リクエストを送る。
- prisma studioで放送情報とトリビアが削除されているか確認する。

Closes #24 