### PR TITLE
APIサーバーをフロント側で簡単に構築できるようにする＆トリビアCUD機能の仕様を少し変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,9 @@
 version: "3"
 
 services:
-  workspace:
-    # 起動するイメージを指定
-    image: node:14.18.0
-
-    container_name: engivia-workspace
-
-    # 環境変数を設定
-    environment:
-      - DEBUG=app:*
-
-    # コンテナを継続させる
-    tty: true
-
-    # ホスト側のポート:コンテナのポート
-    ports:
-      - '8000:8000'
-
-    #（ホスト側の./をコンテナの/appにマウント）
-    # ローカルにデータに残したくない場合は消す
-    volumes:
-      - .:/app
-
-    # 起動時のカレントフォルダを指定
-    working_dir: /app
-
-    depends_on:
-      - mysql
-
-    # 起動後に実行するコマンドを指定
-    command: npm run dev
-
   mysql:
+    # M1チップの場合コメント外す
+    # platform: 'linux/amd64'
     image: mysql:5.7
 
     container_name: engivia-mysql

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fastify": "3.22.0",
     "fastify-autoload": "^3.9.0",
     "fastify-cors": "^6.0.2",
+    "fastify-env": "^2.1.1",
     "fastify-plugin": "^3.0.0",
     "fluent-json-schema": "^3.0.1",
     "jwt-decode": "^3.1.2",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,19 +11,19 @@ async function main() {
       {
         id: 1,
         title: '第１回エンジビアの泉',
-        scheduledStartTime: '2021-10-01T19:00:00Z',
+        scheduledStartTime: '2021-10-01T00:00:00Z',
         status: 'ended',
       },
       {
         id: 2,
         title: '第２回エンジビアの泉',
-        scheduledStartTime: '2021-10-10T12:00:00Z',
+        scheduledStartTime: '2021-10-10T00:00:00Z',
         status: 'live',
       },
       {
         id: 3,
         title: '第３回エンジビアの泉',
-        scheduledStartTime: '2021-10-20T20:00:00Z',
+        scheduledStartTime: '2021-10-20T00:00:00Z',
         status: 'upcoming',
       },
     ],
@@ -101,11 +101,22 @@ async function main() {
     },
   });
 
+  const createAdmin = prisma.user.create({
+    data: {
+      id: 'admin1',
+      name: '管理者１',
+      image: sampleImage,
+      token: 'admin-token1',
+      isAdmin: true
+    }
+  });
+
   await prisma.$transaction([
     createManyBroadcast,
     createUser1,
     createUser2,
     createUser3,
+    createAdmin
   ]);
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,8 +2,30 @@ import { FastifyPluginAsync } from 'fastify';
 import { join } from 'path';
 import AutoLoad from 'fastify-autoload';
 import fastifyCors from 'fastify-cors';
+import fastifyEnv from 'fastify-env';
+import s from 'fluent-json-schema';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    config: { // this should be same as the confKey in options
+      SLACK_CLIENT_ID: string;
+      SLACK_CLIENT_SECRET: string;
+      SLACK_REDIRECT_URL: string
+    };
+  }
+}
 
 export const app: FastifyPluginAsync = async (fastify, opts) => {
+  const schema = s.object()
+    .prop('SLACK_CLIENT_ID', s.string().required())
+    .prop('SLACK_CLIENT_SECRET', s.string().required())
+    .prop('SLACK_REDIRECT_URL', s.string().required())
+  // .env読み込む
+  fastify.register(fastifyEnv, {
+    dotenv: true,
+    schema,
+  });
+
   fastify.register(AutoLoad, {
     dir: join(__dirname, 'plugins'),
     options: opts,
@@ -17,6 +39,7 @@ export const app: FastifyPluginAsync = async (fastify, opts) => {
   // クライアントからアクセスできるようにする
   // 本番環境ではこの設定良くないかも
   fastify.register(fastifyCors, {
-    origin: "*",
+    origin: '*',
   });
+
 };

--- a/src/routes/slack/index.ts
+++ b/src/routes/slack/index.ts
@@ -1,6 +1,6 @@
-import { OpenIDConnectUserInfoResponse, WebClient } from "@slack/web-api";
-import { FastifyPluginAsync } from "fastify";
-import jwt_decode from "jwt-decode";
+import { OpenIDConnectUserInfoResponse, WebClient } from '@slack/web-api';
+import { FastifyPluginAsync } from 'fastify';
+import jwt_decode from 'jwt-decode';
 
 const web = new WebClient();
 
@@ -8,15 +8,15 @@ const slack: FastifyPluginAsync = async (fastify): Promise<void> => {
   // Slack認証画面にリダイレクト
   fastify.get('/signin', async (req, res) => {
     res.redirect(
-      `https://slack.com/openid/connect/authorize?response_type=code&scope=openid%20profile&client_id=${process.env.SLACK_CLIENT_ID}&state=af0ifjsldkj&nonce=abcd&redirect_uri=${process.env.SLACK_REDIRECT_URL}`
+      `https://slack.com/openid/connect/authorize?response_type=code&scope=openid%20profile&client_id=${fastify.config.SLACK_CLIENT_ID}&state=af0ifjsldkj&nonce=abcd&redirect_uri=${fastify.config.SLACK_REDIRECT_URL}`,
     );
   });
 
   fastify.get<{ Querystring: { code: string } }>('/token', async (req, res) => {
     // アクセストークンやIDトークンを取得
     const result = await web.openid.connect.token({
-      client_id: process.env.SLACK_CLIENT_ID || '',
-      client_secret: process.env.SLACK_CLIENT_SECRET || '',
+      client_id: fastify.config.SLACK_CLIENT_ID || '',
+      client_secret: fastify.config.SLACK_CLIENT_SECRET || '',
       code: req.query.code,
     });
     if (!result.id_token || !result.access_token) {
@@ -27,24 +27,28 @@ const slack: FastifyPluginAsync = async (fastify): Promise<void> => {
 
     // id_token をデコードしてユーザー情報を取得
     const userInfo: OpenIDConnectUserInfoResponse = jwt_decode(result.id_token);
-    if (!userInfo["https://slack.com/user_id"] || !userInfo.name || !userInfo.picture) {
+    if (
+      !userInfo['https://slack.com/user_id'] ||
+      !userInfo.name ||
+      !userInfo.picture
+    ) {
       res.status(400).send({ error: 'not found user_id or name or picture' });
       return;
     }
 
     // ユーザー情報をDBに保存
     const registerUser = await fastify.prisma.user.upsert({
-      where: { id: userInfo["https://slack.com/user_id"] },
+      where: { id: userInfo['https://slack.com/user_id'] },
       create: {
-        id: userInfo["https://slack.com/user_id"],
+        id: userInfo['https://slack.com/user_id'],
         name: userInfo.name,
         image: userInfo.picture,
-        token: result.access_token
+        token: result.access_token,
       },
-      update: {}
-    })
+      update: {},
+    });
     res.send(registerUser);
   });
-}
+};
 
 export default slack;

--- a/src/routes/trivia/index.ts
+++ b/src/routes/trivia/index.ts
@@ -13,7 +13,6 @@ type PostBody = {
 };
 
 type PutBody = {
-  id: number;
   content?: string;
   hee?: number;
   featured?: boolean;
@@ -42,17 +41,18 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
     },
   );
 
-  fastify.put<{ Body: PutBody }>(
-    `/`,
+  fastify.put<{ Params: { id: number }, Body: PutBody }>(
+    `/:id`,
     {
       schema: {
         body: bodyPutTriviaSchema,
       },
     },
     async (req, res) => {
-      const { id, content, hee, featured, token } = req.body;
+      const { id } = req.params;
+      const { content, hee, featured, token } = req.body;
       const resultUpdateBroadcastInfo = await fastify.updateTrivia({
-        id,
+        id: Number(id),
         hee,
         content,
         featured,

--- a/src/routes/trivia/schema.ts
+++ b/src/routes/trivia/schema.ts
@@ -6,8 +6,9 @@ export const bodyPostTriviaSchema = s.object()
   .prop('token', s.string().required())
 
 export const bodyPutTriviaSchema = s.object()
-  .prop('id', s.number().minimum(1).required())
-  .prop('content', s.string().maxLength(100).required())
+  .prop('content', s.string().maxLength(100))
+  .prop('featured', s.boolean())
+  .prop('hee', s.number().minimum(0).maximum(100))
   .prop('token', s.string().required())
 
 export const paramsDeleteTrivia = s.object()

--- a/src/routes/trivia/service.ts
+++ b/src/routes/trivia/service.ts
@@ -91,7 +91,7 @@ const triviaPlugin: FastifyPluginAsync = async (fastify) => {
       throw new Error('not found user');
     }
 
-    // ユーザーが管理者の場合、他のユーザーが投稿したトリビアを変更できる
+    // ユーザーが管理者の場合、他のユーザーが投稿したトリビアの内容とへぇカウント、フィーチャーを変更できる
     if (resultUserInfo.isAdmin === true) {
       const resultUpdated = await fastify.prisma.trivia.update({
         where: { id: params.id },
@@ -109,12 +109,11 @@ const triviaPlugin: FastifyPluginAsync = async (fastify) => {
       throw new Error('Cannot update trivia for other users');
     }
 
+    // ユーザーの場合、トリビアの内容のみ変更できる
     const resultUpdated = await fastify.prisma.trivia.update({
       where: { id: params.id },
       data: {
-        content: params.content,
-        hee: params.hee,
-        featured: params.featured
+        content: params.content
       },
     });
     return resultUpdated;

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,7 +351,7 @@ ajv@^6.10.0, ajv@^6.11.0, ajv@^6.12.4, ajv@^6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.1.0:
+ajv@^8.0.0, ajv@^8.1.0:
   version "8.6.3"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz"
   integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
@@ -698,6 +698,16 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-expand@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 duplexify@^4.0.0, duplexify@^4.1.1, duplexify@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz"
@@ -740,6 +750,15 @@ ent@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
   integrity sha1-6WQhkyWiHQX0RGai9obtbOX13R0=
+
+env-schema@^3.0.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/env-schema/-/env-schema-3.4.0.tgz#21d75be4d5cd7aa21603ac5f2d42aa2dea883d8c"
+  integrity sha512-6YN4STYKIRv5YisvjliQAwKoqPaL4S+jzX08G3BFSNc6y0MHWLy89BUaGy708oY3m2teEQJLRAAaXyJlUG4YRQ==
+  dependencies:
+    ajv "^8.0.0"
+    dotenv "^10.0.0"
+    dotenv-expand "^5.1.0"
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -962,6 +981,14 @@ fastify-cors@^6.0.2:
   dependencies:
     fastify-plugin "^3.0.0"
     vary "^1.1.2"
+
+fastify-env@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fastify-env/-/fastify-env-2.1.1.tgz#443cc8f9b443320bfd9330975606fdbb2ba2f799"
+  integrity sha512-5IyYR+d+0/hwae/PpC6oWb+hlMpBqG1MuWWTEbFR2uzGhDXX/rCp4gdBrodt7SndOyvVlF+Z8QZ0fGlXPWtIOw==
+  dependencies:
+    env-schema "^3.0.1"
+    fastify-plugin "^3.0.0"
 
 fastify-error@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
### 変更した部分
- docker-composeでMySQLだけ起動するようにした。APIはローカルで起動
- APIとMySQLサーバーを簡単に用意できるようにした。
- トリビア更新する際、ボディリクエストにトリビアIDを指定していたが、IDをパスパラメーターに含めるように変更した。
- トリビア更新機能で、管理者はトリビアの内容とへぇカウント, フィーチャーを変更できるようにして、ユーザーはトリビアの内容のみ変更できるようにした。

### 確認方法
APIとMySQLコンテナの起動
1. このレポジトリをローカルにクローンする。
2. developブランチから、ブランチ「aopontann/issue#26」に切り替える。
3. Notionの[メモ](https://www.notion.so/b962402189934e799a2d2e55161343dc)を確認しながらAPIとMySQLを起動する。

トリビアCUD機能の確認
1. Notionの[メモ](https://www.notion.so/44c66fd4b4354d32b51ffa2820525198)を見ながら仕様通りに動いているか確認する。

Closes #26 