### PR TITLE
ユーザー情報更新リクエストのバリデーション処理を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@google-cloud/storage": "^5.15.3",
     "@prisma/client": "^3.3.0",
+    "@sinclair/typebox": "^0.20.5",
     "@slack/web-api": "^6.4.0",
     "fastify": "3.22.0",
     "fastify-autoload": "^3.9.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ async function start() {
       prettyPrint: true,
       level: "info",
     },
+    bodyLimit: 1048576 * 5 // 5MiB
   });
   fastify.register(app);
 

--- a/src/plugins/authentication.ts
+++ b/src/plugins/authentication.ts
@@ -1,0 +1,41 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    userInfo: {
+      id: string;
+      name: string;
+      isAdmin: boolean;
+      image: string;
+    };
+  }
+}
+
+const authenticationPlugin: FastifyPluginAsync = fp(async (fastify) => {
+  fastify.decorateRequest('userInfo', null);
+  fastify.addHook(`preValidation`, async (req, reply) => {
+    // 放送一覧を取得する時は、認証はいらない
+    if (req.url === '/broadcast' && req.method === 'GET') return;
+
+    const token = req.headers.authorization?.split(' ')[1];
+    if (!token) {
+      reply.code(403);
+      throw new Error('Specify token');
+    }
+
+    const userInfo = await fastify.prisma.user.findUnique({
+      where: { token },
+      select: { id: true, name: true, isAdmin: true, image: true },
+    });
+
+    if (!userInfo) {
+      reply.code(403);
+      throw new Error('Invalid token');
+    }
+
+    req.userInfo = userInfo;
+  });
+});
+
+export default authenticationPlugin;

--- a/src/routes/trivia/schema.ts
+++ b/src/routes/trivia/schema.ts
@@ -7,7 +7,9 @@ export const bodyPostTriviaSchema = s.object()
 
 export const bodyPutTriviaSchema = s.object()
   .prop('id', s.number().minimum(1).required())
-  .prop('content', s.string().maxLength(100).required())
+  .prop('content', s.string().maxLength(100))
+  .prop('featured', s.boolean())
+  .prop('hee', s.number().minimum(0).maximum(100))
   .prop('token', s.string().required())
 
 export const paramsDeleteTrivia = s.object()

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -1,53 +1,105 @@
 import { FastifyPluginAsync } from 'fastify';
 import userPlugin from './service';
+import {
+  UserInfo,
+  userPutBodySchema,
+  getUserResponse,
+  updateUserResponse,
+  deleteUserResponse,
+  UserPutBody,
+} from './schema';
 
-type PutBody = { name: string; image: string; base64Image?: string };
+declare module 'fastify' {
+  interface FastifyRequest {
+    userInfo: UserInfo;
+  }
+}
 
 const user: FastifyPluginAsync = async (fastify): Promise<void> => {
-  // Broadcastプラグインを読み込む！
   await fastify.register(userPlugin);
+  fastify.decorateRequest('userInfo', null);
 
-  // ユーザー情報取得(idで取得)
-  fastify.get<{
-    Params: { id: string };
-  }>(`/:id`, async (req, res) => {
-    const { id } = req.params;
-    const resultUser = await fastify.getUser({ id });
-    res.send(resultUser);
-  });
+  fastify.addHook<{ Body: { token?: string } }>(
+    'preHandler',
+    async (req, reply, done) => {
+      const token = req.body?.token || req.headers.authorization?.split(' ')[1];
+      if (!token) {
+        reply.code(403);
+        done(new Error('Specify token'));
+      }
+      const userInfo = await fastify.prisma.user.findUnique({
+        where: { token },
+        select: { id: true, name: true, isAdmin: true, image: true },
+      });
+      if (userInfo) {
+        req.userInfo = userInfo;
+        done();
+      } else {
+        reply.code(403);
+        done(new Error('Invalid token'));
+      }
+    },
+  );
 
   // ユーザー情報取得(bearer tokenで取得)
-  fastify.get(`/`, async (req, res) => {
-    const token = req?.headers?.authorization?.split(' ')[1] as string;
-    const resultUser = await fastify.getUser({ token });
-    res.send(resultUser);
-  });
+  fastify.get(
+    `/`,
+    {
+      schema: {
+        response: {
+          '200': getUserResponse,
+        },
+      },
+    },
+    async (req, res) => {
+      res.send(req.userInfo);
+    },
+  );
 
-  // ユーザー情報更新(bearer tokenで更新)
+  // ユーザー情報更新
   fastify.put<{
-    Body: PutBody;
-  }>(`/`, async (req, res) => {
-    const { name, image, base64Image } = req.body;
-    const token = req?.headers?.authorization?.split(' ')[1] as string;
-    const imageURL = base64Image
-      ? await fastify.uploadIcon({ token, base64: base64Image })
-      : image;
-    const updateUser = await fastify.updateUser({
-      token,
-      name,
-      image: imageURL,
-    });
-    res.send(updateUser);
-  });
+    Body: UserPutBody;
+  }>(
+    `/`,
+    {
+      schema: {
+        body: userPutBodySchema,
+        response: {
+          '200': updateUserResponse,
+        },
+      },
+    },
+    async (req, res) => {
+      const { name, image, base64Image } = req.body;
+      const imageURL = base64Image
+        ? await fastify
+            .uploadIcon({ id: req.userInfo.id, base64: base64Image })
+            .catch(() => {
+              throw new Error(`Image upload failed`);
+            })
+        : image;
+      const updatedUser = await fastify.updateUser({
+        id: req.userInfo.id,
+        name,
+        image: imageURL,
+      });
+      res.send(updatedUser);
+    },
+  );
 
   // ユーザー情報削除(bearer tokenで削除)
-  fastify.delete<{
-    Params: { id: string };
-  }>(`/`, async (req, res) => {
-    const token = req?.headers?.authorization?.split(' ')[1] as string;
-    const deleteUser = await fastify.deleteUser({ token });
-    res.send(deleteUser);
-  });
+  fastify.delete(
+    `/`,
+    {
+      schema: {
+        response: { '200': deleteUserResponse },
+      },
+    },
+    async (req, res) => {
+      const deleteUser = await fastify.deleteUser({ id: req.userInfo.id });
+      res.send(deleteUser);
+    },
+  );
 };
 
 export default user;

--- a/src/routes/user/schema.ts
+++ b/src/routes/user/schema.ts
@@ -25,7 +25,7 @@ export const deleteUserResponse = Type.Object({
 export const userPutBodySchema = Type.Object({
   name: Type.Optional(Type.String({ maxLength: 21 })),
   image: Type.Optional(Type.String({ format: 'uri' })),
-  base64: Type.Optional(Type.String()),
+  base64Image: Type.Optional(Type.String()),
   token: Type.String()
 });
 

--- a/src/routes/user/schema.ts
+++ b/src/routes/user/schema.ts
@@ -1,0 +1,48 @@
+import { Trivia, User } from '@prisma/client';
+import { Type } from '@sinclair/typebox';
+
+export const getUserResponse = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  image: Type.String(),
+  isAdmin: Type.Boolean(),
+})
+
+export const updateUserResponse = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  image: Type.String(),
+})
+
+export const deleteUserResponse = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  image: Type.String(),
+  isAdmin: Type.Boolean(),
+  token: Type.String(),
+})
+
+export const userPutBodySchema = Type.Object({
+  name: Type.Optional(Type.String({ maxLength: 21 })),
+  image: Type.Optional(Type.String({ format: 'uri' })),
+  base64: Type.Optional(Type.String()),
+  token: Type.String()
+});
+
+export type UserInfo = {
+  name: string;
+  image: string;
+  id: string;
+  isAdmin: boolean;
+}
+
+export type UserPutBody = {
+  name?: string;
+  image?: string;
+  base64Image?: string;
+  token: string;
+};
+
+export type DeleteUserResult = User & {
+  Trivia: Trivia[];
+}

--- a/src/routes/user/schema.ts
+++ b/src/routes/user/schema.ts
@@ -1,7 +1,6 @@
-import { Trivia, User } from '@prisma/client';
 import { Type } from '@sinclair/typebox';
 
-export const getUserResponse = Type.Object({
+export const userResponse = Type.Object({
   id: Type.String(),
   name: Type.String(),
   image: Type.String(),
@@ -14,19 +13,10 @@ export const updateUserResponse = Type.Object({
   image: Type.String(),
 })
 
-export const deleteUserResponse = Type.Object({
-  id: Type.String(),
-  name: Type.String(),
-  image: Type.String(),
-  isAdmin: Type.Boolean(),
-  token: Type.String(),
-})
-
 export const userPutBodySchema = Type.Object({
   name: Type.Optional(Type.String({ maxLength: 21 })),
   image: Type.Optional(Type.String({ format: 'uri' })),
   base64Image: Type.Optional(Type.String()),
-  token: Type.String()
 });
 
 export type UserInfo = {
@@ -40,9 +30,4 @@ export type UserPutBody = {
   name?: string;
   image?: string;
   base64Image?: string;
-  token: string;
 };
-
-export type DeleteUserResult = User & {
-  Trivia: Trivia[];
-}

--- a/src/routes/user/service.ts
+++ b/src/routes/user/service.ts
@@ -72,6 +72,10 @@ const userPlugin: FastifyPluginAsync = async (fastify) => {
         throw new Error(`Specify id`);
       }
 
+      // 保存されている画像を削除
+      const file = storage.bucket('users_icon').file(`${params.id}.png`);
+      await file.delete({ ignoreNotFound: true });
+
       // ユーザー情報とユーザーが投稿したトリビアを全て削除
       const deleteTrivia = fastify.prisma.trivia.deleteMany({
         where: { userId: params.id },

--- a/src/routes/user/service.ts
+++ b/src/routes/user/service.ts
@@ -1,149 +1,113 @@
-import { Broadcast, User } from '.prisma/client';
+import { User } from '.prisma/client';
 import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 import { Storage } from '@google-cloud/storage';
 
 const storage = new Storage({
   projectId: 'ntm-engivia',
-  keyFilename: 'gcs-token.json'
+  keyFilename: 'gcs-token.json',
 });
 
-interface GetParams {
-  id?: string;
-  token?: string;
-}
-
-interface UpdateParams {
+type UpdateParams = {
+  id: string;
   name?: string;
   image?: string;
-  token: string;
 }
 
-interface DeleteParams {
-  token: string;
+type DeleteParams = {
+  id: string;
 }
 
-interface UploadParams {
-  token: string;
+type UploadParams = {
+  id: string;
   base64: string;
 }
 
+type UpdatedUser = {
+  id: string;
+  name: string;
+  image: string;
+};
+
 declare module 'fastify' {
   interface FastifyInstance {
-    getUser: {
-      // eslint-disable-next-line no-unused-vars
-      (params: GetParams): Promise<User>
-    }
     updateUser: {
       // eslint-disable-next-line no-unused-vars
-      (params: UpdateParams): Promise<Broadcast>
-    }
+      (params: UpdateParams): Promise<UpdatedUser>;
+    };
     deleteUser: {
       // eslint-disable-next-line no-unused-vars
-      (params: DeleteParams): Promise<Broadcast>
-    }
+      (params: DeleteParams): Promise<User>;
+    };
     uploadIcon: {
       // eslint-disable-next-line no-unused-vars
-      (params: UploadParams): Promise<string>
-    }
+      (params: UploadParams): Promise<string>;
+    };
   }
 }
 
 const userPlugin: FastifyPluginAsync = async (fastify) => {
-  // --------------------- ユーザー情報取得 --------------------- //
-  fastify.decorate('getUser', async (params: GetParams) => {
-    if (!params.id && !params.token) {
-      throw new Error('Specify id or token');
-    }
-    if (params.id) {
-      const resultUserInfo = await fastify.prisma.user.findUnique({
-        where: { id: params.id },
-        select: {
-          id: true,
-          name: true,
-          image: true,
-          isAdmin: true
-        },
-      });
-      return resultUserInfo;
-    }
-
-    // token がある場合は、token で user を検索
-    const resultUserInfo = await fastify.prisma.user.findFirst({
-      where: { token: params.token },
+  // ---------------------- ユーザー情報更新 --------------------- //
+  fastify.decorate('updateUser', async (params: UpdateParams): Promise<UpdatedUser> => {
+    const resultUpdateUser = await fastify.prisma.user.update({
+      where: { id: params.id },
+      data: {
+        name: params.name,
+        image: params.image,
+      },
       select: {
         id: true,
         name: true,
         image: true,
-        isAdmin: true
-      }
+      },
     });
-    return resultUserInfo;
-  });
-
-  // ---------------------- ユーザー情報更新 --------------------- //
-  fastify.decorate('updateUser', async (params: UpdateParams) => {
-    const resultUpdateBroadcast = await fastify.prisma.user.update({
-      where: { token: params.token },
-      data: {
-        name: params.name,
-        image: params.image,
-      }
-    });
-    return resultUpdateBroadcast;
+    return resultUpdateUser;
   });
 
   // ---------------------- ユーザー情報削除 --------------------- //
-  fastify.decorate('deleteUser', async (params: DeleteParams) => {
-    const resultGetUser = await fastify.prisma.user.findFirst({
-      where: { token: params.token }
-    });
-
-    if (!resultGetUser) {
-      throw new Error(`not found user`);
-    }
-
-    // ユーザー情報とユーザーが投稿したトリビアを全て削除
-    const deleteUser = await fastify.prisma.user.delete({
-      where: { id: resultGetUser.id },
-      include: {
-        Trivia: {
-          where: { userId: resultGetUser.id }
-        }
+  fastify.decorate(
+    'deleteUser',
+    async (params: DeleteParams): Promise<User> => {
+      if (!params.id) {
+        throw new Error(`Specify id`);
       }
-    });
-    return deleteUser
-  })
+
+      // ユーザー情報とユーザーが投稿したトリビアを全て削除
+      const deleteTrivia = fastify.prisma.trivia.deleteMany({
+        where: { userId: params.id },
+      });
+      const deleteUser = fastify.prisma.user.delete({
+        where: { id: params.id },
+      });
+      const deletedResult = await fastify.prisma.$transaction([
+        deleteTrivia,
+        deleteUser,
+      ]);
+      return deletedResult[1];
+    },
+  );
 
   // ---------------------- ユーザーアイコンアップロード --------------------- //
-  fastify.decorate('uploadIcon', async (params: UploadParams) => {
-    if (!params.token) {
-      throw new Error('Specify id token');
+  fastify.decorate('uploadIcon', async (params: UploadParams): Promise<string> => {
+    if (!params.id || !params.base64) {
+      throw new Error('Specify userId and base64');
     }
 
-    // ユーザー情報を取得
-    const resultUserInfo = await fastify.prisma.user.findUnique({
-      where: { token: params.token }
-    });
-    if (!resultUserInfo) {
-      throw new Error('not found user');
-    }
-
-    const imageBuffer = Buffer.from(params.base64, "base64");
+    const imageBuffer = Buffer.from(params.base64, 'base64');
     // ファイルサイズが5MB以上の場合
     if (imageBuffer.length > 5000000) {
       throw new Error('Image files larger than 5MB cannot be uploaded.');
     }
-    console.log("Byte length: " + imageBuffer.length);
+    console.log('Byte length: ' + imageBuffer.length);
 
     // Cloud Storage に画像をアップロード
-    const file = storage.bucket('users_icon').file(`${resultUserInfo.id}.png`);
+    const file = storage.bucket('users_icon').file(`${params.id}.png`);
     await file.save(imageBuffer).catch((e) => {
       console.error(e);
       throw new Error('upload failure');
     });
-    return `https://storage.googleapis.com/users_icon/${resultUserInfo.id}.png`;
-  })
-}
+    return `https://storage.googleapis.com/users_icon/${params.id}.png`;
+  });
+};
 
 export default fp(userPlugin);

--- a/src/routes/user/service.ts
+++ b/src/routes/user/service.ts
@@ -102,12 +102,12 @@ const userPlugin: FastifyPluginAsync = async (fastify) => {
     if (imageBuffer.length > 5000000) {
       throw new Error('Image files larger than 5MB cannot be uploaded.');
     }
-    console.log('Byte length: ' + imageBuffer.length);
+    fastify.log.info('Byte length: ' + imageBuffer.length);
 
     // Cloud Storage に画像をアップロード
     const file = storage.bucket('users_icon').file(`${params.id}.png`);
     await file.save(imageBuffer).catch((e) => {
-      console.error(e);
+      fastify.log.error(e);
       throw new Error('upload failure');
     });
     return `https://storage.googleapis.com/users_icon/${params.id}.png`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,6 +146,11 @@
   resolved "https://registry.npmjs.org/@prisma/engines/-/engines-3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c.tgz"
   integrity sha512-T3nEnRWmoneNZJPd9IBR29G8ZDUjNelA8+cG5y8/lh6vySm6ryWSNxj1s377U9YzFYyZmXiA9vK1iyxMoRff/g==
 
+"@sinclair/typebox@^0.20.5":
+  version "0.20.5"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.20.5.tgz#d5828bbb8237876d7937dd229e3dac71d1220771"
+  integrity sha512-WNiVFcS1rdz5KyEutpl3Wmp/AwSQHBUFTyJz7KqMLkpLhOXCj1dnvMytBM6uMS5OTwhwwq877T7EC4vDGrX5Eg==
+
 "@slack/logger@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz"


### PR DESCRIPTION
## 変更理由
- ユーザーの情報を更新する時、長すぎる名前を登録できないようにするため。
- 画像をアップロードする時、画像サイズの上限を設定するため。
- ユーザーが退会したとき、アップロードされた画像を削除するため。
- トリビアのバリデーション機能に不具合があり修正をするため。

## 変更箇所
- バリデーションに[Typebox](https://github.com/sinclairzx81/typebox)を使うことにした。
- ユーザーの名前を変更する時、22文字以上の名前を指定できないバリデーションを実装した。
- ユーザーの画像を変更する時、サイズが5MB以上の画像はアップロードできないようにした。
- ユーザー情報を削除する時、GCSに保存されている画像を削除する機能を実装した。
  - 画像が保存されていない場合もある。
  - GCSに画像がない時は、エラーにならずそのままスルーされるようにした。
- トリビアを更新する時、heeはNumber型で0から100までの数値を登録できる、featuredはBoolean型のバリデーションを実装した。

## 確認事項
- [ ]  ユーザー名を変更するとき、21文字以内の名前は更新できて、22文字以上の名前は変更できないようになっているか。
- [ ] 画像サイズが5MB以上の画像をアップロードできないようになっているか。
- [ ] ユーザー情報を削除した時、GCS上の画像が削除されているか。
- [ ] トリビアを更新するとき、heeを0から100の数値以外を指定したとき、更新できないようになっているか。
- [ ] トリビアを更新するとき、featuredをboolean型以外を指定したとき、更新できないようになっているか。
  - string型の "true", "false"はバリデーションが通るようになっている。
  
## 画像アップロードまでの流れ
1. 画像が削除されていることを確認する前にGCSに画像をアップロードする必要がある。
2. まず最初にGCPのサービスアカウントのキーを取得する必要がある。Notionに[ドキュメント](https://www.notion.so/GCS-acf7da75041948e1a99281c7a7496fc4)書いておきましたので参考してください。
3. アップロードしたい画像をこの[サイト](https://rakko.tools/tools/72/)でbase64エンコードする
4. エンコードした後、「プレーンテキスト - Base64データのみ」をコピーする。（コピーボタンをクリック）
5. Postmanで PUT /user リクエストボディ(base64Image)にコピーしたものを貼り付ける。
6. リクエストを送りGCSに画像がアップロードされているか確認する。

## 仕様の変更について
- ユーザー情報を更新する時、リクエストボディにトークンを含めず、ヘッダーにトークンを入れることにした。
  - 今後、放送情報やトリビアの認証の作成・更新する時もヘッダーのトークンを使うように仕様変更をする予定。