### PR TITLE
✨ 放送情報CRUD＆放送リスト取得バリデーションの実装

### DIFF
--- a/src/plugins/authentication.ts
+++ b/src/plugins/authentication.ts
@@ -15,10 +15,15 @@ declare module 'fastify' {
 const authenticationPlugin: FastifyPluginAsync = fp(async (fastify) => {
   fastify.decorateRequest('userInfo', null);
   fastify.addHook(`preValidation`, async (req, reply) => {
-    // 放送一覧を取得する時は、認証はいらない
+    // 放送一覧を取得する時は、事前に認証処理は必要ない
     if (req.url === '/broadcast' && req.method === 'GET') return;
+    
+    // Slack認証をする時は、事前に認証処理は必要ない
+    const slackUrlRegexp = /\/slack\/[^/]+$/;
+    if (slackUrlRegexp.test(req.url)) return;
 
     const token = req.headers.authorization?.split(' ')[1];
+
     if (!token) {
       reply.code(403);
       throw new Error('Specify token');

--- a/src/routes/broadcast/preHandler.ts
+++ b/src/routes/broadcast/preHandler.ts
@@ -15,6 +15,9 @@ export const broadcastPreHandlerPlugin: FastifyPluginAsync = fp(async (fastify) 
         throw new Error('Only admin can access');
       }
 
+      // 放送を作成するとき、放送が存在するかの事前チェックしない
+      if (req.method === 'POST') return;
+      
       // 放送が存在するか事前チェックする
       const resultBroadcast = await fastify.getBroadcast({
         id: Number(req.params.id),

--- a/src/routes/broadcast/preHandler.ts
+++ b/src/routes/broadcast/preHandler.ts
@@ -1,0 +1,28 @@
+import { FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+
+export const broadcastPreHandlerPlugin: FastifyPluginAsync = fp(async (fastify) => {
+  fastify.addHook<{ Params: { id: number } }>(
+    'preHandler',
+    async (req, res) => {
+      // 放送一覧を取得するとき、以下(11行目から)の処理は行わない
+      if (req.url === '/broadcast' && req.method === 'GET') return;
+
+      // 管理者のみ放送を作成・更新・削除できるようにする
+      const broadcastmeshodRegexp = /POST|PUT|DELETE/;
+      if (!req.userInfo?.isAdmin && broadcastmeshodRegexp.test(req.method)) {
+        res.code(403);
+        throw new Error('Only admin can access');
+      }
+
+      // 放送が存在するか事前チェックする
+      const resultBroadcast = await fastify.getBroadcast({
+        id: Number(req.params.id),
+      });
+      if (!resultBroadcast) {
+        res.code(400);
+        throw new Error('not found broadcast');
+      }
+    },
+  )
+});

--- a/src/routes/broadcast/schema.ts
+++ b/src/routes/broadcast/schema.ts
@@ -1,0 +1,59 @@
+import { Type, Static } from '@sinclair/typebox';
+
+export const broadcastParamsSchema = Type.Object({
+  id: Type.Number(),
+});
+
+export const broadcastPostBodySchema = Type.Object({
+  title: Type.String(),
+  scheduledStartTime: Type.String({ format: 'date-time' }),
+});
+
+export const broadcastPutBodySchema = Type.Object({
+  title: Type.Optional(Type.String()),
+  scheduledStartTime: Type.Optional(Type.String({ format: 'date-time' })),
+  status: Type.Optional(Type.String({ pattern: 'upcoming|live|ended' })),
+  archiveUrl: Type.Optional(Type.String({ format: 'uri' })),
+});
+
+export type BroadcastPostBody = Static<typeof broadcastPostBodySchema>;
+export type BroadcastPutBody = Static<typeof broadcastPutBodySchema>;
+
+export const broadcastListGetResponseSchema = Type.Array(
+  Type.Object({
+    id: Type.String(),
+    title: Type.String(),
+    scheduledStartTime: Type.String(),
+    status: Type.String(),
+    _count: Type.Union([Type.Object({ Trivia: Type.Number() }), Type.Null()]),
+  }),
+);
+
+export const broadcastGetResponseSchema = Type.Object({
+  id: Type.String(),
+  title: Type.String(),
+  scheduledStartTime: Type.String(),
+  status: Type.String(),
+  archiveUrl: Type.Union([Type.String(), Type.Null()]),
+  Trivia: Type.Array(
+    Type.Object({
+      id: Type.Number(),
+      content: Type.String(),
+      hee: Type.Union([Type.Number(), Type.Null()]),
+      featured: Type.Boolean(),
+      User: Type.Object({
+        id: Type.String(),
+        name: Type.String(),
+        image: Type.String(),
+      }),
+    }),
+  ),
+});
+
+export const broadcastPostPutDeleteResponseSchema = Type.Object({
+  id: Type.String(),
+  title: Type.String(),
+  scheduledStartTime: Type.String(),
+  status: Type.String(),
+  archiveUrl: Type.Union([Type.String(), Type.Null()]),
+})

--- a/src/routes/broadcast/service.ts
+++ b/src/routes/broadcast/service.ts
@@ -1,141 +1,103 @@
-import { Broadcast, Prisma, Trivia, User } from '.prisma/client';
+import { Broadcast, Prisma } from '.prisma/client';
 import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
-
-interface GetParams {
-  id: number;
-  token: string;
-}
-
-interface CreateParams {
-  title: string;
-  scheduledStartTime: string;
-  token: string;
-}
-
-interface UpdateParams {
-  id: number;
-  title?: string;
-  scheduledStartTime?: string;
-  status?: string;
-  archiveUrl?: string;
-  token: string;
-}
-
-interface DeleteParams {
-  id: number;
-  token: string;
-}
+import {
+  CreateBroadcastParams,
+  DeleteBroadcastParams,
+  GetBroadcastListResponse,
+  GetBroadcastParams,
+  GetBroadcastResponse,
+  UpdateBroadcastParams,
+} from './type';
 
 declare module 'fastify' {
   interface FastifyInstance {
     getBroadcast: {
       // eslint-disable-next-line no-unused-vars
-      (params: GetParams): Promise<
-        Broadcast & {
-          Trivia:
-            | (Trivia & {
-                User: User;
-              })[]
-            | undefined;
-        }
-      >;
+      (params: GetBroadcastParams): Promise<GetBroadcastResponse>;
     };
     getBroadcastList: {
       // eslint-disable-next-line no-unused-vars
-      (): Promise<Broadcast>;
+      (): Promise<GetBroadcastListResponse>;
     };
     createBroadcast: {
       // eslint-disable-next-line no-unused-vars
-      (params: CreateParams): Promise<Broadcast>;
+      (params: CreateBroadcastParams): Promise<Broadcast>;
     };
     updateBroadcast: {
       // eslint-disable-next-line no-unused-vars
-      (params: UpdateParams): Promise<Broadcast>;
+      (params: UpdateBroadcastParams): Promise<Broadcast>;
     };
     deleteBroadcast: {
       // eslint-disable-next-line no-unused-vars
-      (params: DeleteParams): Promise<Broadcast>;
+      (params: DeleteBroadcastParams): Promise<Broadcast>;
     };
   }
 }
 
-const broadcastPlugin: FastifyPluginAsync = async (fastify) => {
+export const broadcastServicePlugin: FastifyPluginAsync = fp(async (fastify) => {
   // ---------------------- 放送リスト取得 --------------------- //
-  fastify.decorate('getBroadcastList', async () => {
-    const resultBroadcastList = await fastify.prisma.broadcast.findMany({
-      select: {
-        id: true,
-        title: true,
-        scheduledStartTime: true,
-        status: true,
-        _count: { select: { Trivia: true } },
-      },
-    });
-    return resultBroadcastList;
-  });
+  fastify.decorate(
+    'getBroadcastList',
+    async (): Promise<GetBroadcastListResponse> => {
+      const resultBroadcastList = await fastify.prisma.broadcast.findMany({
+        select: {
+          id: true,
+          title: true,
+          scheduledStartTime: true,
+          status: true,
+          _count: { select: { Trivia: true } },
+        },
+      });
+      return resultBroadcastList;
+    },
+  );
 
   // --------------------- 放送情報取得 --------------------- //
-  fastify.decorate('getBroadcast', async (params: GetParams) => {
-    if (!params.id || !params.token) {
-      throw new Error('Specify id and token');
-    }
-    // ユーザー情報を取得
-    const resultUserInfo = await fastify.prisma.user.findUnique({
-      where: { token: params.token },
-    });
-    if (!resultUserInfo) {
-      throw new Error('not found userInfo');
-    }
+  fastify.decorate(
+    'getBroadcast',
+    async (params: GetBroadcastParams): Promise<GetBroadcastResponse> => {
+      // ユーザーが管理者でない場合、ユーザーの投稿したトリビアのみ取得するwhere文が作成される
+      const whereTrivia: Prisma.TriviaWhereInput | undefined =
+        params.isAdmin === false
+          ? {
+              OR: [
+                { Broadcast: { status: 'ended' } },
+                { userId: params.userId },
+              ],
+            }
+          : undefined;
 
-    // ユーザーが管理者でない場合、ユーザーの投稿したトリビアのみ取得するwhere文が作成される
-    const whereTrivia: Prisma.TriviaWhereInput | undefined =
-      resultUserInfo.isAdmin === false
-        ? {
-            OR: [
-              { Broadcast: { status: 'ended' } },
-              { userId: resultUserInfo.id },
-            ],
-          }
-        : undefined;
-
-    // 放送情報を取得
-    const resultBroadcast = await fastify.prisma.broadcast.findUnique({
-      where: { id: params.id },
-      include: {
-        Trivia: {
-          where: whereTrivia,
-          include: {
-            User: {
-              select: {
-                id: true,
-                name: true,
-                image: true,
+      // 放送情報を取得
+      const resultBroadcast = await fastify.prisma.broadcast.findUnique({
+        where: { id: params.id },
+        include: {
+          Trivia: {
+            where: whereTrivia,
+            select: {
+              id: true,
+              content: true,
+              hee: true,
+              featured: true,
+              User: {
+                select: {
+                  id: true,
+                  name: true,
+                  image: true,
+                },
               },
             },
           },
         },
-      },
-    });
-    return resultBroadcast;
-  });
+      });
+      return resultBroadcast;
+    },
+  );
 
   // ---------------------- 放送作成 --------------------- //
-  fastify.decorate('createBroadcast', async (params: CreateParams) => {
-    if (!params.token) {
-      throw new Error('Specify token');
-    }
-    // ユーザー情報取得
-    const resultUserInfo = await fastify.prisma.user.findUnique({
-      where: { token: params.token },
-    });
-
-    if (!resultUserInfo) {
-      throw new Error('Invalid token');
-    }
-
-    // 管理者の場合
-    if (resultUserInfo?.isAdmin === true) {
+  fastify.decorate(
+    'createBroadcast',
+    async (params: CreateBroadcastParams): Promise<Broadcast> => {
       const resultCreateBroadcast = await fastify.prisma.broadcast.create({
         data: {
           title: params.title,
@@ -143,24 +105,13 @@ const broadcastPlugin: FastifyPluginAsync = async (fastify) => {
         },
       });
       return resultCreateBroadcast;
-    }
-
-    // 管理者ではない場合
-    throw new Error('not admin');
-  });
+    },
+  );
 
   // ---------------------- 放送情報更新 --------------------- //
-  fastify.decorate('updateBroadcast', async (params: UpdateParams) => {
-    if (!params.token) {
-      throw new Error('Specify token');
-    }
-    // ユーザー情報取得
-    const resultUserInfo = await fastify.prisma.user.findUnique({
-      where: { token: params.token },
-    });
-
-    // 管理者の場合
-    if (resultUserInfo?.isAdmin === true) {
+  fastify.decorate(
+    'updateBroadcast',
+    async (params: UpdateBroadcastParams): Promise<Broadcast> => {
       const resultUpdateBroadcast = await fastify.prisma.broadcast.update({
         where: { id: params.id },
         data: {
@@ -171,37 +122,25 @@ const broadcastPlugin: FastifyPluginAsync = async (fastify) => {
         },
       });
       return resultUpdateBroadcast;
-    }
-
-    // 管理者ではない場合
-    throw new Error('not admin');
-  });
+    },
+  );
 
   // ---------------------- 放送削除 --------------------- //
-  fastify.decorate('deleteBroadcast', async (params: DeleteParams): Promise<Broadcast> => {
-    if (!params.token) {
-      throw new Error('Specify token');
-    }
-    // ユーザー情報取得
-    const resultUserInfo = await fastify.prisma.user.findUnique({
-      where: { token: params.token },
-    });
-
-    // 管理者の場合
-    if (resultUserInfo?.isAdmin === true) {
+  fastify.decorate(
+    'deleteBroadcast',
+    async (params: DeleteBroadcastParams): Promise<Broadcast> => {
+      // 管理者の場合
       const deleteBroadcast = fastify.prisma.broadcast.delete({
         where: { id: params.id },
       });
       const deleteTrivia = fastify.prisma.trivia.deleteMany({
-        where: { broadcastId: params.id }
+        where: { broadcastId: params.id },
       });
-      const result = await fastify.prisma.$transaction([deleteTrivia, deleteBroadcast]);
+      const result = await fastify.prisma.$transaction([
+        deleteTrivia,
+        deleteBroadcast,
+      ]);
       return result[1];
-    }
-
-    // 管理者ではない場合
-    throw new Error('not admin');
-  });
-};
-
-export default fp(broadcastPlugin);
+    },
+  );
+});

--- a/src/routes/broadcast/type.ts
+++ b/src/routes/broadcast/type.ts
@@ -1,0 +1,50 @@
+import { Broadcast } from "@prisma/client";
+
+export type GetBroadcastParams = {
+  id: number;
+  isAdmin?: boolean;
+  userId?: string;
+};
+
+export type CreateBroadcastParams = {
+  title: string;
+  scheduledStartTime: string;
+};
+
+export type UpdateBroadcastParams = {
+  id: number;
+  title?: string;
+  scheduledStartTime?: string;
+  status?: string;
+  archiveUrl?: string;
+};
+
+export type DeleteBroadcastParams = {
+  id: number;
+};
+
+export type GetBroadcastListResponse = {
+  id: number;
+  title: string;
+  scheduledStartTime: Date;
+  status: string;
+  _count: {
+    Trivia: number;
+  } | null;
+}[];
+
+export type GetBroadcastResponse =
+  | (Broadcast & {
+      Trivia: {
+        id: number;
+        content: string;
+        hee: number | null;
+        featured: boolean;
+        User: {
+          id: string;
+          name: string;
+          image: string;
+        };
+      }[];
+    })
+  | null;

--- a/src/routes/slack/index.ts
+++ b/src/routes/slack/index.ts
@@ -23,7 +23,6 @@ const slack: FastifyPluginAsync = async (fastify): Promise<void> => {
       res.status(400).send({ error: 'not found id_token or access_token' });
       return;
     }
-    res.send(result);
 
     // id_token をデコードしてユーザー情報を取得
     const userInfo: OpenIDConnectUserInfoResponse = jwt_decode(result.id_token);
@@ -45,7 +44,9 @@ const slack: FastifyPluginAsync = async (fastify): Promise<void> => {
         image: userInfo.picture,
         token: result.access_token,
       },
-      update: {},
+      update: {
+        token: result.access_token,
+      },
     });
     res.send(registerUser);
   });


### PR DESCRIPTION
## 変更の概要
1. クライアントから放送をCRUD（作成・取得・更新・削除）するリクエストがきたとき、リクエストボディやパラメータの値が不正な値が指定されていないかチェックする（バリデーション）機能を実装した。
2. APIがレスポンスを返すとき、[出力スキーマ](https://www.fastify.io/docs/latest/Validation-and-Serialization/#serialization)を使用するようにした。（Serialization：シリアライゼーション←読み方合ってるか分からん）
3. 型定義をtype.tsに書くようにした。
4. 管理者ではないユーザーが放送を作成・更新・削除しようとしたとき、403エラーを返す処理を作成した。
5. `/slack/signin`, `/slack/token`, `/broadcast` にアクセスするとき、Bearerトークンで認証を行わないようにした。

## 変更した理由
1. バリデーション機能を実装することで、不正な値を事前に弾いてエラーを返すことができるため。
2. 出力スキーマを使用することで、スループット（コンピュータやネットワーク機器が単位時間あたりに処理できるデータ量）が向上し、機密情報の偶発的な開示を防ぐことができるため。
3. リファクタリングするため。
4. 管理者ではないユーザーが放送を作成・更新・削除されることを防ぐため。
5. トークンを使ったユーザー認証が必要ないため。

## 変更内容
1. 以下の条件のとき、バリデーションエラーを返すようにした。
  - `放送日(scheduledStartTime)`をdate-time型(例:"2021-10-10T12:00:00Z")以外を指定したとき
  - `放送状況(status)`を`upcoming`, `live`, `ended`のString型以外指定したとき
  - `アーカイブURL(archiveUrl)`をURL形式のString型以外を指定したとき
2. シリアライゼーションに使う出力スキーマをschema.tsに書いた。詳細はソースコードみてください。
3. broadcastServicePluginで宣言した関数の引数の型や返り値の型宣言をtype.tsに書いた。
4. preHandlerイベントを追加して、そのイベントで管理者ではないユーザーが放送の作成・更新・削除エンドポイントにアクセスしたとき、403エラーを返すようにした。
5. preValidationイベントを追加して、そのイベントで`/slack/signin`, `/slack/token`, `/broadcast`にアクセスしたとき、認証処理をスルーするようにした。

## 動作確認
- [ ] `POST /broadcast`, `PUT broadcast/:id`のリクエストボディのプロパティ`scheduledStartTime`にdate-time型以外の値を指定してリクエストを送ったとき、レスポンスステータスコード(以下：Status)400が返ってくるか
- [ ] `PUT broadcast/:id`のリクエストボディのプロパティ`status`に`upcoming`, `live`, `ended`のString型以外指定したとき、Status:400が返ってくるか
- [ ] `PUT broadcast/:id`のリクエストボディのプロパティ`archiveUrl`にURL形式のString型以外を指定したとき、Status:400が返ってくるか
- [ ] `POST /broadcast`, `PUT /broadcast`, `DELETE /broadcast`に管理者ではないユーザーがアクセスしたとき、Status:403が返ってくるか

## 参考
- https://www.fastify.io/docs/latest/Validation-and-Serialization/#serialization
- https://www.fastify.io/docs/latest/Hooks/#prevalidation
- https://www.fastify.io/docs/latest/Hooks/#prehandler

Closes #15