### PR TITLE
トリビア作成・更新するとき、認証でBearerトークンを用いるように修正した

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+	"printWidth": 120
 }

--- a/src/routes/trivia/index.ts
+++ b/src/routes/trivia/index.ts
@@ -5,6 +5,7 @@ import {
   triviaPostBodySchema,
   triviaPutBpdySchema,
   triviaDeleteParamsSchema,
+  triviaPostPutDeleteResponseSchema,
   TriviaPostBody,
   TriviaPutBody,
 } from './schema';
@@ -20,6 +21,7 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
     {
       schema: {
         body: triviaPostBodySchema,
+        response: { '201': triviaPostPutDeleteResponseSchema },
       },
     },
     async (req, res) => {
@@ -29,7 +31,7 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
         broadcastId,
         userId: req.userInfo.id,
       });
-      res.send(resultUpdateBroadcastInfo);
+      res.status(201).send(resultUpdateBroadcastInfo);
     },
   );
 
@@ -38,6 +40,7 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
     {
       schema: {
         body: triviaPutBpdySchema,
+        response: { '200': triviaPostPutDeleteResponseSchema },
       },
     },
     async (req, res) => {
@@ -57,7 +60,12 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
 
   fastify.delete<{ Params: { id: number } }>(
     `/:id`,
-    { schema: { params: triviaDeleteParamsSchema } },
+    {
+      schema: {
+        params: triviaDeleteParamsSchema,
+        response: { '200': triviaPostPutDeleteResponseSchema },
+      },
+    },
     async (req, res) => {
       const { id } = req.params;
       const resultDeleteTriviaInfo = await fastify.deleteTrivia({

--- a/src/routes/trivia/index.ts
+++ b/src/routes/trivia/index.ts
@@ -2,22 +2,12 @@ import { FastifyPluginAsync } from 'fastify';
 import { triviaPlugin } from './service';
 import { triviaPreHandlerPlugin } from './preHandler';
 import {
-  bodyPostTriviaSchema,
-  bodyPutTriviaSchema,
-  paramsDeleteTrivia,
+  triviaPostBodySchema,
+  triviaPutBpdySchema,
+  triviaDeleteParamsSchema,
+  TriviaPostBody,
+  TriviaPutBody,
 } from './schema';
-
-type PostBody = {
-  content: string;
-  broadcastId: number;
-};
-
-type PutBody = {
-  content?: string;
-  hee?: number;
-  featured?: boolean;
-  token: string;
-};
 
 const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
   // Triviaプラグインを読み込む！
@@ -25,11 +15,11 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
   // 事前チェック
   await fastify.register(triviaPreHandlerPlugin);
 
-  fastify.post<{ Body: PostBody }>(
+  fastify.post<{ Body: TriviaPostBody }>(
     `/`,
     {
       schema: {
-        body: bodyPostTriviaSchema,
+        body: triviaPostBodySchema,
       },
     },
     async (req, res) => {
@@ -43,11 +33,11 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
     },
   );
 
-  fastify.put<{ Params: { id: number }; Body: PutBody }>(
+  fastify.put<{ Params: { id: number }; Body: TriviaPutBody }>(
     `/:id`,
     {
       schema: {
-        body: bodyPutTriviaSchema,
+        body: triviaPutBpdySchema,
       },
     },
     async (req, res) => {
@@ -67,7 +57,7 @@ const trivia: FastifyPluginAsync = async (fastify): Promise<void> => {
 
   fastify.delete<{ Params: { id: number } }>(
     `/:id`,
-    { schema: { params: paramsDeleteTrivia } },
+    { schema: { params: triviaDeleteParamsSchema } },
     async (req, res) => {
       const { id } = req.params;
       const resultDeleteTriviaInfo = await fastify.deleteTrivia({

--- a/src/routes/trivia/index.ts
+++ b/src/routes/trivia/index.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginAsync } from 'fastify';
-import triviaPlugin from './service';
+import { triviaPlugin } from './service';
 import { triviaPreHandlerPlugin } from './preHandler';
 import {
   bodyPostTriviaSchema,

--- a/src/routes/trivia/preHandler.ts
+++ b/src/routes/trivia/preHandler.ts
@@ -1,0 +1,53 @@
+import { FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+
+export const triviaPreHandlerPlugin: FastifyPluginAsync = fp(async (fastify) => {
+  fastify.addHook<{ Params: { id: number }, Body: { content: string, broadcastId: number } }>(
+    'preHandler',
+    async (req, res) => {
+      // トリビアを作成するとき、既にトリビアが保存されているかチェックする
+      if (req.method === 'POST') {
+        // 管理者はエンジビアを投稿できない
+        if (req.userInfo.isAdmin) {
+          res.code(400);
+          throw new Error('Admin are not allowed to post engivia.');
+        }
+        const resultTrivia = await fastify.prisma.trivia.findFirst({
+          where: {
+            AND: [
+              { userId: req.userInfo.id },
+              { broadcastId: req.body.broadcastId }
+            ]
+          }
+        });
+        // 既に投稿している場合
+        if (resultTrivia) {
+          res.code(400);
+          throw new Error('The engivia has already been posted.');
+        }
+        // 投稿されていない場合
+        return;
+      }
+
+      // 投稿したエンジビアがあるかチェック
+      if (/PUT|DELETE/.test(req.method)) {
+        const resultTrivia = await fastify.prisma.trivia.findUnique({
+          where: { id: Number(req.params.id) },
+        });
+
+        // 指定したIDが存在する場合
+        if (resultTrivia) {
+          // 管理者・投稿したユーザー本人の場合
+          if (req.userInfo.isAdmin || resultTrivia.userId === req.userInfo.id) return;
+          // 他のユーザーが投稿したエンジビアを更新・削除しようとしたとき
+          res.code(400);
+          throw new Error(`It is not possible to update or delete another user's endivia.`);
+        }
+
+        // IDが存在しない場合
+        res.code(400);
+        throw new Error('Engivia not found.');
+      }
+    },
+  )
+});

--- a/src/routes/trivia/preHandler.ts
+++ b/src/routes/trivia/preHandler.ts
@@ -2,64 +2,63 @@ import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 
 type triviaPostPutBpdy = {
-  content: string,
-  broadcastId: number,
-  hee: number,
-  featured: boolean,
-}
+  content: string;
+  broadcastId: number;
+  hee: number;
+  featured: boolean;
+};
 
 export const triviaPreHandlerPlugin: FastifyPluginAsync = fp(async (fastify) => {
-  fastify.addHook<{ Params: { id: number }, Body: triviaPostPutBpdy }>(
-    'preHandler',
-    async (req, res) => {
-      // トリビアを作成するとき、既にトリビアが保存されているかチェックする
-      if (req.method === 'POST') {
-        // 管理者はエンジビアを投稿できない
-        if (req.userInfo.isAdmin) {
-          res.code(400);
-          throw new Error('Admin are not allowed to post engivia.');
-        }
-        const resultTrivia = await fastify.prisma.trivia.findFirst({
-          where: {
-            AND: [
-              { userId: req.userInfo.id },
-              { broadcastId: req.body.broadcastId }
-            ]
-          }
-        });
-        // 既に投稿している場合
-        if (resultTrivia) {
-          res.code(400);
-          throw new Error('The engivia has already been posted.');
-        }
-        // 投稿されていない場合
-        return;
+  fastify.addHook<{ Params: { id: number }; Body: triviaPostPutBpdy }>('preHandler', async (req, res) => {
+    // トリビアを作成するとき、既にトリビアが保存されているかチェックする
+    if (req.method === 'POST') {
+      // 管理者はエンジビアを投稿できない
+      if (req.userInfo.isAdmin) {
+        res.code(400);
+        throw new Error('Admin are not allowed to post engivia.');
       }
+      const resultTrivia = await fastify.prisma.trivia.findFirst({
+        where: {
+          AND: [{ userId: req.userInfo.id }, { broadcastId: req.body.broadcastId }],
+        },
+      });
+      // 既に投稿している場合
+      if (resultTrivia) {
+        res.code(400);
+        throw new Error('The engivia has already been posted.');
+      }
+      // 投稿されていない場合
+      return;
+    }
 
-      // 投稿したエンジビアがあるかチェック
-      if (/PUT|DELETE/.test(req.method)) {
-        const resultTrivia = await fastify.prisma.trivia.findUnique({
-          where: { id: Number(req.params.id) },
-        });
+    // 投稿したエンジビアがあるかチェック
+    if (/PUT|DELETE/.test(req.method)) {
+      const resultTrivia = await fastify.prisma.trivia.findUnique({
+        where: { id: Number(req.params.id) },
+      });
 
-        // 指定したIDが存在する場合
-        if (resultTrivia) {
-          // 管理者ではないユーザーはへぇカウント、フィーチャーを更新できない
-          if (!req.userInfo.isAdmin && (req.body.featured !== undefined || req.body.hee !== undefined)) {
-            res.code(403);
-            throw new Error(`The user cannot update the featured and hee.`);
-          }
-          // 管理者・投稿したユーザー本人の場合
-          if (req.userInfo.isAdmin || resultTrivia.userId === req.userInfo.id) return;
-          // 他のユーザーが投稿したエンジビアを更新・削除しようとしたとき
-          res.code(403);
-          throw new Error(`It is not possible to update or delete another user's endivia.`);
-        }
-
-        // IDが存在しない場合
+      // エンジビアが存在しない場合
+      if (!resultTrivia) {
         res.code(400);
         throw new Error('Engivia not found.');
       }
-    },
-  )
+
+      // 管理者ではないユーザーはへぇカウント、フィーチャーを更新できない
+      if (
+        !req.userInfo.isAdmin &&
+        req.method === 'PUT' &&
+        (req.body.featured !== undefined || req.body.hee !== undefined)
+      ) {
+        res.code(403);
+        throw new Error(`The user cannot update the featured and hee.`);
+      }
+
+      // 管理者・投稿したユーザー本人の場合
+      if (req.userInfo.isAdmin || resultTrivia.userId === req.userInfo.id) return;
+
+      // 他のユーザーが投稿したエンジビアを更新・削除しようとしたとき
+      res.code(403);
+      throw new Error(`It is not possible to update or delete another user's endivia.`);
+    }
+  });
 });

--- a/src/routes/trivia/schema.ts
+++ b/src/routes/trivia/schema.ts
@@ -6,13 +6,22 @@ export const triviaPostBodySchema = Type.Object({
 });
 
 export const triviaPutBpdySchema = Type.Object({
-  content: Type.String({ maxLength: 100 }),
-  featured: Type.Boolean(),
-  hee: Type.Number({ minimum: 1, maximum: 100 }),
+  content: Type.Optional(Type.String({ maxLength: 100 })),
+  featured: Type.Optional(Type.Boolean()),
+  hee: Type.Optional(Type.Number({ minimum: 1, maximum: 100 })),
 });
 
 export const triviaDeleteParamsSchema = Type.Object({
   id: Type.Number({ minimum: 1 }),
+});
+
+export const triviaPostPutDeleteResponseSchema = Type.Object({
+  id: Type.Number(),
+  content: Type.String(),
+  hee: Type.Union([Type.Number(), Type.Null()]),
+  featured: Type.Boolean(),
+  userId: Type.String(),
+  broadcastId: Type.Number()
 });
 
 export type TriviaPostBody = Static<typeof triviaPostBodySchema>;

--- a/src/routes/trivia/schema.ts
+++ b/src/routes/trivia/schema.ts
@@ -1,13 +1,19 @@
-import s from "fluent-json-schema";
+import { Type, Static } from '@sinclair/typebox';
 
-export const bodyPostTriviaSchema = s.object()
-  .prop('content', s.string().maxLength(100).required())
-  .prop('broadcastId', s.number().minimum(1).required())
+export const triviaPostBodySchema = Type.Object({
+  content: Type.String({ maxLength: 100 }),
+  broadcastId: Type.Number({ minimum: 1 }),
+});
 
-export const bodyPutTriviaSchema = s.object()
-  .prop('content', s.string().maxLength(100))
-  .prop('featured', s.boolean())
-  .prop('hee', s.number().minimum(0).maximum(100))
+export const triviaPutBpdySchema = Type.Object({
+  content: Type.String({ maxLength: 100 }),
+  featured: Type.Boolean(),
+  hee: Type.Number({ minimum: 1, maximum: 100 }),
+});
 
-export const paramsDeleteTrivia = s.object()
-  .prop('id', s.number().minimum(1).required())
+export const triviaDeleteParamsSchema = Type.Object({
+  id: Type.Number({ minimum: 1 }),
+});
+
+export type TriviaPostBody = Static<typeof triviaPostBodySchema>;
+export type TriviaPutBody = Static<typeof triviaPutBpdySchema>;

--- a/src/routes/trivia/schema.ts
+++ b/src/routes/trivia/schema.ts
@@ -3,13 +3,11 @@ import s from "fluent-json-schema";
 export const bodyPostTriviaSchema = s.object()
   .prop('content', s.string().maxLength(100).required())
   .prop('broadcastId', s.number().minimum(1).required())
-  .prop('token', s.string().required())
 
 export const bodyPutTriviaSchema = s.object()
   .prop('content', s.string().maxLength(100))
   .prop('featured', s.boolean())
   .prop('hee', s.number().minimum(0).maximum(100))
-  .prop('token', s.string().required())
 
 export const paramsDeleteTrivia = s.object()
   .prop('id', s.number().minimum(1).required())

--- a/src/routes/trivia/service.ts
+++ b/src/routes/trivia/service.ts
@@ -1,47 +1,31 @@
 import { Prisma, Trivia } from '.prisma/client';
 import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
-
-interface UpdateParams {
-  id: number;
-  content?: string;
-  hee?: number;
-  featured?: boolean;
-  userId: string;
-  isAdmin: boolean;
-}
-
-interface CreateParams {
-  userId: string;
-  content: string;
-  broadcastId: number;
-}
-
-interface DeleteParams {
-  id: number;
-}
+import {
+  CreateTriviaParams,
+  UpdateTriviaParams,
+  DeleteTriviaParams,
+} from './type';
 
 declare module 'fastify' {
   interface FastifyInstance {
     createTrivia: {
       // eslint-disable-next-line no-unused-vars
-      (params: CreateParams): Promise<Trivia>;
+      (params: CreateTriviaParams): Promise<Trivia>;
     };
     updateTrivia: {
       // eslint-disable-next-line no-unused-vars
-      (params: UpdateParams): Promise<Trivia>;
+      (params: UpdateTriviaParams): Promise<Trivia>;
     };
     deleteTrivia: {
       // eslint-disable-next-line no-unused-vars
-      (params: DeleteParams): Promise<Trivia>;
+      (params: DeleteTriviaParams): Promise<Trivia>;
     };
   }
 }
 
 export const triviaPlugin: FastifyPluginAsync = fp(async (fastify) => {
-  // ---------------------- 放送情報更新 --------------------- //
-
-  fastify.decorate('createTrivia', async (params: CreateParams) => {
+  fastify.decorate('createTrivia', async (params: CreateTriviaParams) => {
     // トリビア投稿
     const resultCreated = await fastify.prisma.trivia.create({
       data: {
@@ -53,7 +37,7 @@ export const triviaPlugin: FastifyPluginAsync = fp(async (fastify) => {
     return resultCreated;
   });
 
-  fastify.decorate('updateTrivia', async (params: UpdateParams) => {
+  fastify.decorate('updateTrivia', async (params: UpdateTriviaParams) => {
     // ユーザーが管理者の場合、他のユーザーが投稿したトリビアの内容とへぇカウント、フィーチャーを変更できる
     // ユーザーの場合、トリビアの内容のみ変更できる
     const updateData: Prisma.TriviaUpdateInput =
@@ -74,12 +58,11 @@ export const triviaPlugin: FastifyPluginAsync = fp(async (fastify) => {
     return resultUpdated;
   });
 
-  fastify.decorate('deleteTrivia', async (params: DeleteParams) => {
+  fastify.decorate('deleteTrivia', async (params: DeleteTriviaParams) => {
     // ユーザーがトリビアを投稿していたら、そのユーザーがトリビアを削除できる
     const resultDeleted = await fastify.prisma.trivia.delete({
       where: { id: params.id },
     });
-
     return resultDeleted;
   });
 });

--- a/src/routes/trivia/type.ts
+++ b/src/routes/trivia/type.ts
@@ -1,0 +1,18 @@
+export type UpdateTriviaParams = {
+  id: number;
+  content?: string;
+  hee?: number;
+  featured?: boolean;
+  userId: string;
+  isAdmin: boolean;
+}
+
+export type CreateTriviaParams = {
+  userId: string;
+  content: string;
+  broadcastId: number;
+}
+
+export type DeleteTriviaParams = {
+  id: number;
+}


### PR DESCRIPTION
## 変更の概要
1. トリビアを作成・更新するリクエストを送るとき、リクエストボディにトークンを含めて認証をしていたが、Bearerトークン（ヘッダーのAuthorizationにトークンを入れる）を用いて認証をするように変更した。
2.  管理者以外へぇカウント、フィーチャーを更新できないようにした

## 変更した理由
1. 以前は、POST, PUTリクエストの時はボディのトークンで認証をして、GET, DELETEリクエストの時はBearer認証をしていた。メゾットごとに認証方法が違うとちょっとめんどくさいので、Bearer認証で統一するようにした。
2. 仕様では、ユーザーがへぇカウント, フィーチャーを更新することができないことになっているため。
 
## 変更箇所
- preHandlerイベントを作成し、指定したトリビアIDが存在するのかチェックする処理、1つの放送につき, ユーザーは1つしかトリビアを投稿できないようにする処理、管理者はトリビアが投稿できないようにする処理、管理者以外のユーザーが他のユーザーのトリビアを編集・削除できないようにする処理を実装した。
- httpレスポンスに出力スキーマを用いるようにした。
- 型データを`type.ts`, `schema.ts`からインポートするようにリファクタリングした。

## 動作確認
- [x] Bearerトークンとリクエストボディを指定して、POST `/trivia`にリクエストを飛ばし、トリビアが投稿されているか(Status: 201)
- [x] トリビアを更新・削除するリクエストを送るときに存在しないトリビアIDを指定するとエラーになるか（Status: 400）
- [x] ある放送にトリビアを投稿して成功した後、同じ放送に再び投稿するとエラーになるか（Status: 400）
- [x] 管理者はトリビアを投稿できないようになっているか（Status: 400）
- [x] 管理者以外は他のユーザーが投稿したトリビアを更新・削除できないようになっているか（Status: 403）

Closes #32