### PR TITLE
自動でCloud Runにデプロイするようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN yarn
 
 COPY . /app
 
+RUN yarn prisma:generate
 RUN yarn build
 
 FROM node:14.17.0 as release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:14.17.0 as builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock /app/
+
+ENV DATABASE_URL=${DATABASE_URL}
+
+RUN yarn
+
+COPY . /app
+
+RUN yarn build
+
+FROM node:14.17.0 as release
+
+COPY --from=builder /app/dist /app/package.json /app/yarn.lock /app/prisma/schema.prisma /app/
+
+ENV NODE_ENV=production
+ENV DATABASE_URL=${DATABASE_URL}
+
+WORKDIR /app
+# NODE_ENVを production にすると、devDependenciesがインストールされない
+RUN yarn
+
+EXPOSE 8080
+
+CMD [ "yarn", "start" ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "ts-node-dev --transpile-only --exit-child src/index.ts",
+    "prisma:generate": "prisma generate",
     "build": "tsc",
     "start": "node src/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "dev": "ts-node-dev --transpile-only --exit-child src/index.ts"
+    "dev": "ts-node-dev --transpile-only --exit-child src/index.ts",
+    "build": "tsc",
+    "start": "node src/index.js"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.15.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,8 @@ import fastifyCors from 'fastify-cors';
 import fastifyEnv from 'fastify-env';
 import s from 'fluent-json-schema';
 
+// デプロイテスト
+
 declare module 'fastify' {
   interface FastifyInstance {
     config: { // this should be same as the confKey in options


### PR DESCRIPTION
## 概要

developブランチにpushすると、自動でデプロイされるようにインフラを構築した。
Dockerfileを記述した以外に、Cloud Consoleでボタンポチポチしてインフラの設定をした。
Cloud Runにアクセスして放送一覧を取得できるようになったが、絶対どこかにバグがありそう。

## 新たな課題

- 開発と本番用でcorsを設定する必要がありそう。

Closes #37 