### PR TITLE
BroadcastテーブルのscheduledStartTimeカラムのデータ型をdatetime型に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^5.15.3",
-    "@prisma/client": "^3.3.0",
+    "@prisma/client": "^3.6.0",
     "@sinclair/typebox": "^0.20.5",
     "@slack/web-api": "^6.4.0",
     "fastify": "3.22.0",
@@ -25,7 +25,7 @@
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.0",
     "prettier": "^2.4.1",
-    "prisma": "^3.3.0",
+    "prisma": "^3.6.0",
     "ts-node": "10.3.0",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.4.3"

--- a/prisma/migrations/20211202132800_scheduled_date_to_datetime/migration.sql
+++ b/prisma/migrations/20211202132800_scheduled_date_to_datetime/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Broadcast` MODIFY `scheduledStartTime` DATETIME NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,7 +36,7 @@ model Trivia {
 model Broadcast {
   id                 Int      @id @default(autoincrement())
   title              String
-  scheduledStartTime DateTime @db.Date
+  scheduledStartTime DateTime @db.DateTime()
   status             String   @default("upcoming")
   archiveUrl         String?
   Trivia             Trivia[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,22 +129,22 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@prisma/client@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/@prisma/client/-/client-3.3.0.tgz"
-  integrity sha512-34tonDW2v74VcG1mx+k/IUGG/eSHKwDiYKfFIZgaPLq/C0h8YQxh7pro272xpOf1pt6duX1Bi90dpGijh1MYgQ==
+"@prisma/client@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.6.0.tgz#68a60cd4c73a369b11f72e173e86fd6789939293"
+  integrity sha512-ycSGY9EZGROtje0iCNsgC5Zqi/ttX2sO7BNMYaLsUMiTlf3F69ZPH+08pRo0hrDfkZzyimXYqeXJlaoYDH1w7A==
   dependencies:
-    "@prisma/engines-version" "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+    "@prisma/engines-version" "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
 
-"@prisma/engines-version@3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
-  resolved "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c.tgz"
-  integrity sha512-g21xPYq0zHoJ/xUkNxIf5Hle0oiDyelZHU8gwq7J3RNVrccjbUZ28S99KT4yUabV8SQQRNSnR0QMLGMv9Eqs/A==
+"@prisma/engines-version@3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727":
+  version "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz#25aa447776849a774885866b998732b37ec4f4f5"
+  integrity sha512-vtoO2ys6mSfc8ONTWdcYztKN3GBU1tcKBj0aXObyjzSuGwHFcM/pEA0xF+n1W4/0TAJgfoPX2khNEit6g0jtNA==
 
-"@prisma/engines@3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
-  resolved "https://registry.npmjs.org/@prisma/engines/-/engines-3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c.tgz"
-  integrity sha512-T3nEnRWmoneNZJPd9IBR29G8ZDUjNelA8+cG5y8/lh6vySm6ryWSNxj1s377U9YzFYyZmXiA9vK1iyxMoRff/g==
+"@prisma/engines@3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727":
+  version "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz#c68ede6aeffa9ef7743a32cfa6daf9172a4e15b3"
+  integrity sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==
 
 "@sinclair/typebox@^0.20.5":
   version "0.20.5"
@@ -1762,12 +1762,12 @@ prettier@^2.4.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
-prisma@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/prisma/-/prisma-3.3.0.tgz"
-  integrity sha512-E7C9mXRwZVpcnSeJT533qGHUVrYULsE9ihFvAtQMuxhTXkxoRlMLyo/1ZOyeu9GdXP8DJ7ruLOw06kEs/N3dVg==
+prisma@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.6.0.tgz#99532abc02e045e58c6133a19771bdeb28cecdbe"
+  integrity sha512-6SqgHS/5Rq6HtHjsWsTxlj+ySamGyCLBUQfotc2lStOjPv52IQuDVpp58GieNqc9VnfuFyHUvTZw7aQB+G2fvQ==
   dependencies:
-    "@prisma/engines" "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+    "@prisma/engines" "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
## 概要
schema.prismaのBroadcastテーブルのscheduledStartTimeを`db.date()`から`db.datetime()`に変更した

## 変更した理由
放送を作成するとき、フロントからリクエストボディに放送タイトルと放送日(`2021-12-03T00:00:00+09:00`)が含まれたリクエストが送られてくる。
`db.date()`だと、年月日までのデータまでしか保存されないため、DBに`2021-12-02T00:00:00Z`(UTC時刻に変換されてその年月日までのデータ)で保存されてしまう。
これだと、放送日を取得してUTC時刻からJST時刻に変換するとき、放送作成したときに指定した日付と違う時刻になってしまう。（取得した日付に＋１日すれば良いかもしれないが...）
`db.datetime()`にすれば、上記の問題を防げると思うため変更した。

## 確認事項
- [ ] `POST /broadcast`リクエストを送ったとき、放送日が年から秒まで保存されているか。

Closes #36