### PR TITLE
✨ テキストを音声化するAPI実装

### DIFF
--- a/src/lib/textToSpeech.ts
+++ b/src/lib/textToSpeech.ts
@@ -10,7 +10,7 @@ export const getTitleCallAudio = async (text: string) => {
   const [response] = await client.synthesizeSpeech({
     input: { text },
     voice: { languageCode: 'ja-JP' },
-    audioConfig: { audioEncoding: 'MP3' }
+    audioConfig: { audioEncoding: 'MP3', pitch: 5.0 },
   });
   if (!response.audioContent) {
     throw new Error('synthesizeSpeech error');
@@ -18,7 +18,7 @@ export const getTitleCallAudio = async (text: string) => {
   const base64encoded = Buffer.from(response.audioContent).toString('base64');
   console.log(`base64encoded: ${base64encoded}`);
   return base64encoded;
-}
+};
 
 /*
 const base64Sound = getTitleCallAudio('こんにちは');

--- a/src/routes/live/index.ts
+++ b/src/routes/live/index.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 import { Socket } from 'socket.io';
+import { getTitleCallAudio } from '../../lib/textToSpeech';
 
 const live: FastifyPluginAsync = async (fastify): Promise<void> => {
   // liveプラグインを読み込む！
@@ -27,8 +28,8 @@ const live: FastifyPluginAsync = async (fastify): Promise<void> => {
       await fastify.io.emit('get_connect_user', joiningUsers);
 
       // 管理者がタイトルコールした時、エンジビア情報を受け取る
-      socket.on('post_title_call', (data) => {
-        console.info(data);
+      socket.on('post_title_call', async (data) => {
+        const sound = await getTitleCallAudio(data.query.content);
         // 受け取ったエンジビア情報をユーザーに送信
         fastify.io.emit('get_title_call', {
           engivia: {
@@ -37,6 +38,7 @@ const live: FastifyPluginAsync = async (fastify): Promise<void> => {
             image: data.query.image,
             content: data.query.content,
             engiviaNumber: Number(data.query.engiviaNumber),
+            heeSound: sound,
           },
         });
       });


### PR DESCRIPTION
変更点
- タイトルコール時にgetTitleCallAudio()を実行させて、ユーザー側に音声データを送信する


https://github.com/non-Tokyo-Manjikai/engivia-frontend/pull/107
以降、フロントのプルリクを参照してください